### PR TITLE
更新python版本

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.13
 
       - name: Random sleep
         if: github.event_name == 'schedule'


### PR DESCRIPTION
最近github action使用python3.7版本提示没有这个版本，更新一下python版本到最新的3.13
![image](https://github.com/user-attachments/assets/7dea1eb0-3052-4310-9ec7-1043e527bfd6)
![image](https://github.com/user-attachments/assets/24d55aae-3521-45cf-999c-c836eb57076a)
