### PR TITLE
多账号登陆有问题，已经修复 There was a problem with multiple account login, which has been fixed

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,9 +36,10 @@ def sign(order,user,pwd):
                         push_url = 'https://sctapi.ftqq.com/{}.send?title=机场签到&desp={}'.format(SCKEY, content)
                         requests.post(url=push_url)
                         print('推送成功')
-        except:
+        except Exception as ex:
                 content = '签到失败'
                 print(content)
+                print("出现如下异常%s"%ex)
                 if SCKEY != '':
                         push_url = 'https://sctapi.ftqq.com/{}.send?title=机场签到&desp={}'.format(SCKEY, content)
                         requests.post(url=push_url)

--- a/main.py
+++ b/main.py
@@ -25,10 +25,14 @@ def sign(order,user,pwd):
         try:
                 print(f'===账号{order}进行登录...===')
                 print(f'账号：{user}')
-                response = json.loads(session.post(url=login_url,headers=header,data=data).text)
+                res = session.post(url=login_url,headers=header,data=data).text
+                print(res)
+                response = json.loads(res)
                 print(response['msg'])
                 # 进行签到
-                result = json.loads(session.post(url=check_url,headers=header).text)
+                res2 = session.post(url=check_url,headers=header).text
+                print(res2)
+                result = json.loads(res2)
                 print(result['msg'])
                 content = result['msg']
                 # 进行推送

--- a/main.py
+++ b/main.py
@@ -1,6 +1,4 @@
 import requests, json, re, os
-
-session = requests.session()
 # 机场的地址
 url = os.environ.get('URL')
 # 配置用户名（一般是邮箱）
@@ -13,6 +11,7 @@ login_url = '{}/auth/login'.format(url)
 check_url = '{}/user/checkin'.format(url)
 
 def sign(order,user,pwd):
+        session = requests.session()
         global url,SEKEY
         header = {
         'origin': url,


### PR DESCRIPTION
如果使用原本代码进行多账号登陆打卡，因为session.post(url=login_url,headers=header,data=data).text多个账号共用同一个cookie，会导致cookie已经记录第一个账号信息，之后所有账号都会打卡失败。
已经将session = requests.session()初始化放入每个循环用来清除cookie，这样实测多账号打卡能够成功。

If you use the original code to log in multiple accounts, because session.post(url=login_url,headers=header,data=data).text multiple accounts share the same cookie, the cookie will record the first account information, and all subsequent accounts will fail to log in.
The session = requests.session() initialization has been put into each loop to clear the cookie, so that the actual test of multiple account clocking in can be successful.
<img width="608" alt="Screenshot 2025-05-19 at 15 10 06" src="https://github.com/user-attachments/assets/32f09a2d-7906-44a2-8d5f-548c137a8706" />
